### PR TITLE
fix: send a defaultConfig flag to prevent init with default config 

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.test.ts
@@ -1,0 +1,76 @@
+import { Server } from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import sinon from 'ts-sinon'
+import { LocalProjectContextServer } from './localProjectContextServer'
+
+describe('LocalProjectContextServer', () => {
+    let features: TestFeatures
+    let server: Server
+    let disposeServer: () => void
+
+    beforeEach(() => {
+        features = new TestFeatures()
+        server = LocalProjectContextServer()
+        disposeServer = server(features)
+    })
+
+    afterEach(() => {
+        sinon.restore()
+        disposeServer()
+        features.dispose()
+    })
+
+    it('should skip init when isDefaultConfig is true', async () => {
+        // Mock the service manager methods
+        const mockServiceManager = {
+            addDidChangeConfigurationListener: sinon.stub().resolves(),
+        }
+        sinon
+            .stub(
+                require('../../shared/amazonQServiceManager/AmazonQTokenServiceManager'),
+                'getOrThrowBaseTokenServiceManager'
+            )
+            .returns(mockServiceManager)
+        sinon.stub(require('../../shared/utils'), 'isUsingIAMAuth').returns(false)
+
+        await features.initialize(server)
+
+        // Get the configuration listener that was registered
+        const configListener = mockServiceManager.addDidChangeConfigurationListener.firstCall.args[0]
+
+        // Call it with default config
+        await configListener({ isDefaultConfig: true })
+
+        sinon.assert.calledWith(
+            features.logging.log,
+            'Skipping local project context initialization for default config'
+        )
+    })
+
+    it('should call init when isDefaultConfig is false', async () => {
+        // Mock the service manager methods
+        const mockServiceManager = {
+            addDidChangeConfigurationListener: sinon.stub().resolves(),
+        }
+        sinon
+            .stub(
+                require('../../shared/amazonQServiceManager/AmazonQTokenServiceManager'),
+                'getOrThrowBaseTokenServiceManager'
+            )
+            .returns(mockServiceManager)
+        sinon.stub(require('../../shared/utils'), 'isUsingIAMAuth').returns(false)
+
+        await features.initialize(server)
+
+        // Get the configuration listener that was registered
+        const configListener = mockServiceManager.addDidChangeConfigurationListener.firstCall.args[0]
+
+        // Call it with non-default config
+        await configListener({
+            isDefaultConfig: false,
+            projectContext: { enableLocalIndexing: true },
+        })
+
+        sinon.assert.calledWith(features.logging.log, sinon.match(/Setting project context indexing enabled to/))
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -164,6 +164,11 @@ export const LocalProjectContextServer =
         const updateConfigurationHandler = async (updatedConfig: AmazonQWorkspaceConfig) => {
             logging.log('Updating configuration of local context server')
             try {
+                if (updatedConfig.isDefaultConfig === true) {
+                    logging.log('Skipping init for default config')
+                    return
+                }
+
                 localProjectContextEnabled = updatedConfig.projectContext?.enableLocalIndexing === true
                 if (process.env.DISABLE_INDEXING_LIBRARY === 'true') {
                     logging.log('Skipping local project context initialization')

--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -165,7 +165,7 @@ export const LocalProjectContextServer =
             logging.log('Updating configuration of local context server')
             try {
                 if (updatedConfig.isDefaultConfig === true) {
-                    logging.log('Skipping init for default config')
+                    logging.log('Skipping local project context initialization for default config')
                     return
                 }
 

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -100,7 +100,10 @@ interface CodeWhispererConfigSection {
     sendUserWrittenCodeMetrics: boolean
 }
 
-export type AmazonQWorkspaceConfig = QConfigSection & CodeWhispererConfigSection
+export type AmazonQWorkspaceConfig = QConfigSection &
+    CodeWhispererConfigSection & {
+        isDefaultConfig?: boolean
+    }
 
 /**
  * Attempts to fetch the workspace configurations set in:
@@ -184,6 +187,7 @@ export async function getAmazonQRelatedWorkspaceConfigs(
     return {
         ...qConfig,
         ...codeWhispererConfig,
+        isDefaultConfig: false,
     }
 }
 
@@ -212,6 +216,7 @@ export const defaultAmazonQWorkspaceConfigFactory = (): AmazonQWorkspaceConfig =
                 indexCacheDirPath: undefined,
             },
         },
+        isDefaultConfig: true,
     }
 }
 


### PR DESCRIPTION
## Problem
Currently the LocalProjectContextController does not respect real config setting for indexing, only the default configuration is called and the real configuration is thrown away if the first call is not finished yet. Thus, the vector indexing won't start and the cache indexing is broken. 

## Solution
Add a defaultConfig flag to make LocalProjectContextController prevent init with default config and only execute the real config 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
