### PR TITLE
fix(amazonq): Fixes mcp server registry not clearing on switching connections and reduces GetProfile calls

### DIFF
--- a/core/aws-lsp-core/src/util/retryUtils.ts
+++ b/core/aws-lsp-core/src/util/retryUtils.ts
@@ -34,18 +34,18 @@ export interface RetryOptions {
  */
 function defaultIsRetryable(error: any): boolean {
     const errorCode = error.code || error.name
-    const statusCode = error.statusCode
+    const statusCode = error.statusCode || error?.$metadata?.httpStatusCode
 
     // Fast fail on non-retryable client errors (except throttling)
     if (statusCode >= CLIENT_ERROR_MIN && statusCode < CLIENT_ERROR_MAX && errorCode !== THROTTLING_EXCEPTION) {
         return false
     }
 
-    // Retry on throttling, server errors, and specific status codes
+    // Retry on throttling, server errors (5xx), and specific status codes
     return (
         errorCode === THROTTLING_EXCEPTION ||
         errorCode === INTERNAL_SERVER_EXCEPTION ||
-        statusCode === INTERNAL_SERVER_ERROR ||
+        statusCode >= 500 ||
         statusCode === SERVICE_UNAVAILABLE
     )
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -1840,6 +1840,10 @@ export class McpManager {
         }
     }
 
+    public resetRegistryService(): void {
+        this.registryService = undefined
+    }
+
     /**
      * Update registry URL and refetch registry
      * @throws Error if registry fetch or validation fails

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -1853,8 +1853,6 @@ export class McpManager {
             this.registryService = new McpRegistryService(this.features.logging)
         }
 
-        const wasActive = this.registryUrlProvided
-
         try {
             const registry = await this.registryService.fetchRegistry(registryUrl)
             if (registry) {
@@ -1862,19 +1860,13 @@ export class McpManager {
                 // Clear any previous registry errors on success
                 this.configLoadErrors.delete('registry')
 
-                if (!wasActive) {
+                this.features.logging.info(`MCP Registry: Registry mode ACTIVATED - ${registry.servers.length} servers`)
+                // Only discover servers when registry is newly activated and not during periodic sync
+                if (!isPeriodicSync) {
+                    await this.discoverAllServers()
                     this.features.logging.info(
-                        `MCP Registry: Registry mode ACTIVATED - ${registry.servers.length} servers`
+                        `MCP: discovered ${this.getAllTools().length} tools after registry activation`
                     )
-                    // Only discover servers when registry is newly activated and not during periodic sync
-                    if (!isPeriodicSync) {
-                        await this.discoverAllServers()
-                        this.features.logging.info(
-                            `MCP: discovered ${this.getAllTools().length} tools after registry activation`
-                        )
-                    }
-                } else {
-                    this.features.logging.info(`MCP Registry: Updated registry with ${registry.servers.length} servers`)
                 }
 
                 // Only sync during periodic updates, not at startup

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
@@ -14,7 +14,6 @@ import { EventEmitter } from 'events'
 import { McpRegistryService } from './mcpRegistryService'
 import { McpRegistryData } from './mcpTypes'
 import { GetProfileResponse } from '@amzn/codewhisperer-runtime'
-import { McpManager } from './mcpManager'
 
 export const AUTH_SUCCESS_EVENT = 'authSuccess'
 
@@ -184,10 +183,16 @@ export class ProfileStatusMonitor {
     }
 
     static resetMcpManager(): void {
-        if (McpManager.isInitialized()) {
-            McpManager.instance.setRegistryActive(false)
-            McpManager.instance.resetRegistryService()
-            void McpManager.instance.close(true)
+        try {
+            // note: use dynamic require to satisfy webpack requirements for webworker
+            const { McpManager } = require('./mcpManager')
+            if (McpManager.isInitialized()) {
+                McpManager.instance.setRegistryActive(false)
+                McpManager.instance.resetRegistryService()
+                void McpManager.instance.close(true)
+            }
+        } catch (error) {
+            ProfileStatusMonitor.logging?.error(`Failed to reset MCP manager: ${error}`)
         }
     }
 
@@ -196,8 +201,14 @@ export class ProfileStatusMonitor {
      * re-discover mcp servers for non-profile connections
      */
     static discoverServersWhenNoProfiles(): void {
-        if (McpManager.isInitialized()) {
-            void McpManager.instance.discoverAllServers()
+        try {
+            // note: use dynamic require to satisfy webpack requirements for webworker
+            const { McpManager } = require('./mcpManager')
+            if (McpManager.isInitialized()) {
+                void McpManager.instance.discoverAllServers()
+            }
+        } catch (error) {
+            ProfileStatusMonitor.logging?.error(`Failed to discover mcp servers when no profiles available: ${error}`)
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
@@ -191,14 +191,14 @@ export class ProfileStatusMonitor {
         }
     }
 
-    static discoverMcpServers(): void {
+    /**
+     * When switching between connections especially builder id
+     * re-discover mcp servers for non-profile connections
+     */
+    static discoverServersWhenNoProfiles(): void {
         if (McpManager.isInitialized()) {
             void McpManager.instance.discoverAllServers()
         }
-    }
-
-    static isMcpManagerInitialized(): boolean {
-        return McpManager.isInitialized()
     }
 
     static emitAuthSuccess(): void {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
@@ -14,6 +14,7 @@ import { EventEmitter } from 'events'
 import { McpRegistryService } from './mcpRegistryService'
 import { McpRegistryData } from './mcpTypes'
 import { GetProfileResponse } from '@amzn/codewhisperer-runtime'
+import { McpManager } from './mcpManager'
 
 export const AUTH_SUCCESS_EVENT = 'authSuccess'
 
@@ -180,6 +181,24 @@ export class ProfileStatusMonitor {
 
     static resetMcpState(): void {
         ProfileStatusMonitor.setMcpState(true)
+    }
+
+    static resetMcpManager(): void {
+        if (McpManager.isInitialized()) {
+            McpManager.instance.setRegistryActive(false)
+            McpManager.instance.resetRegistryService()
+            void McpManager.instance.close(true)
+        }
+    }
+
+    static discoverMcpServers(): void {
+        if (McpManager.isInitialized()) {
+            void McpManager.instance.discoverAllServers()
+        }
+    }
+
+    static isMcpManagerInitialized(): boolean {
+        return McpManager.isInitialized()
     }
 
     static emitAuthSuccess(): void {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
@@ -185,7 +185,7 @@ export class ProfileStatusMonitor {
     static resetMcpManager(): void {
         try {
             // note: use dynamic require to satisfy webpack requirements for webworker
-            const { McpManager } = require('./mcpManager')
+            const McpManager = eval('require')('./mcpManager').McpManager
             if (McpManager.isInitialized()) {
                 McpManager.instance.setRegistryActive(false)
                 McpManager.instance.resetRegistryService()
@@ -203,7 +203,7 @@ export class ProfileStatusMonitor {
     static discoverServersWhenNoProfiles(): void {
         try {
             // note: use dynamic require to satisfy webpack requirements for webworker
-            const { McpManager } = require('./mcpManager')
+            const McpManager = eval('require')('./mcpManager').McpManager
             if (McpManager.isInitialized()) {
                 void McpManager.instance.discoverAllServers()
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -461,8 +461,8 @@ export const McpToolsServer: Server = ({
             // Wait for profile ARN to be available before checking MCP state
             const checkAndInitialize = async () => {
                 try {
-                    // Check if MCP is enabled via isMcpEnabled check (only call once)
-                    const mcpEnabled = await profileStatusMonitor!.checkInitialState()
+                    // Check if MCP is enabled via get Mcp state
+                    const mcpEnabled = ProfileStatusMonitor.getMcpState()
 
                     if (mcpEnabled) {
                         logging.info('MCP is enabled, discovering servers')

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -163,6 +163,7 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
         ProfileStatusMonitor.resetMcpState()
         if (McpManager.isInitialized()) {
             McpManager.instance.setRegistryActive(false)
+            McpManager.instance.resetRegistryService()
             void McpManager.instance.close(true)
         }
     }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -37,8 +37,6 @@ import { parse } from '@aws-sdk/util-arn-parser'
 import { ChatDatabase } from '../../language-server/agenticChat/tools/chatDb/chatDb'
 import { ProfileStatusMonitor } from '../../language-server/agenticChat/tools/mcp/profileStatusMonitor'
 import { UserContext } from '@amzn/codewhisperer-runtime'
-import { McpManager } from '../../language-server/agenticChat/tools/mcp/mcpManager'
-
 /**
  * AmazonQTokenServiceManager manages state and provides centralized access to
  * instance of CodeWhispererServiceToken SDK client to any consuming code.
@@ -161,11 +159,7 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
 
         // Reset MCP state cache when auth changes
         ProfileStatusMonitor.resetMcpState()
-        if (McpManager.isInitialized()) {
-            McpManager.instance.setRegistryActive(false)
-            McpManager.instance.resetRegistryService()
-            void McpManager.instance.close(true)
-        }
+        ProfileStatusMonitor.resetMcpManager()
     }
 
     public handleOnCredentialsUpdated(type: CredentialsType): void {
@@ -270,9 +264,8 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
             )
             this.state = 'INITIALIZED'
             this.logging.log(`Initialized Amazon Q service with ${newConnectionType} connection`)
-            if (McpManager.isInitialized()) {
-                void McpManager.instance.discoverAllServers()
-            }
+
+            ProfileStatusMonitor.discoverServersWhenNoProfiles()
 
             return
         }


### PR DESCRIPTION

## Description
This changes addresses to issues:
1. With JB it was observed that `GetProfile` calls may get invoked a large number of times when service returned 5xx errors. With this change an attempt has been made to reduce the number of time `GetProfile` call may get invoked by the `profileStatusMonitor.IsMcpEnabeld` call.
2. A bug was found where within a single IDE session when switching between connections IDC/Builder ID, if previously signed in with a mcp registry enabled profile, signing out and logging into a builder id or IDC without registry resulted in still being able to access servers from the previous connection's registry. This change ensures, mcp servers are cleared and registry reset on signout.

Testing
Validated that less IsMcpEnabled calls are invoked and mcp servers are cleared on switching connections

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
