### PR TITLE
fix: support inline completions in Docker Compose files

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/languageDetection.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/languageDetection.test.ts
@@ -33,6 +33,13 @@ describe('LanguageDetection', () => {
                 )
             }
         })
+
+        it(`maps the 'dockercompose' language id (used by some IDEs for docker-compose files) to yaml`, () => {
+            assert.strictEqual(
+                getLanguageId(TextDocument.create('test://docker-compose.yaml', 'dockercompose', 1, '')),
+                'yaml'
+            )
+        })
     })
 
     describe('getSupportedLanguageId', () => {
@@ -40,6 +47,11 @@ describe('LanguageDetection', () => {
         it('should return language id if it is in the list of supported languages', () => {
             assert.ok(getSupportedLanguageId(typescriptDocument, ['typescript', 'javascript']))
             assert.ok(!getSupportedLanguageId(typescriptDocument, ['javascript']))
+        })
+
+        it('should support docker-compose files reported with the dockercompose language id', () => {
+            const dockerComposeDocument = TextDocument.create('test://docker-compose.yaml', 'dockercompose', 1, '')
+            assert.strictEqual(getSupportedLanguageId(dockerComposeDocument), 'yaml')
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
@@ -177,6 +177,9 @@ export const qLanguageIdByDocumentLanguageId: { [key: string]: CodewhispererLang
     vue: 'vue',
     yaml: 'yaml',
     yml: 'yaml',
+    // Some IDEs (e.g. VS Code) report docker-compose files with the 'dockercompose'
+    // language id rather than 'yaml'; treat it as YAML so completions are provided.
+    dockercompose: 'yaml',
 }
 
 export const getSupportedLanguageId = (


### PR DESCRIPTION
## Problem

Amazon Q inline suggestions are not provided in Docker Compose files. Some IDEs (notably VS Code) identify `docker-compose.yaml` / `docker-compose.yml` with the editor language id `dockercompose` rather than `yaml`.

In `shared/languageDetection.ts`, `getLanguageId` resolves a document's language by:
1. looking up the editor language id in `qLanguageIdByDocumentLanguageId`, then
2. falling back to the file extension via `languageByExtension`.

`dockercompose` was not present in `qLanguageIdByDocumentLanguageId`, so the language id itself resolved to "unsupported". These files only worked when the extension fallback happened to match `.yaml`/`.yml`, and the inline completion handler logs `languageId [dockercompose] not supported` for the language-id path.

## Fix

Map `dockercompose` to `yaml` in `qLanguageIdByDocumentLanguageId`, so the language is resolved directly from the reported language id (and consistently with the existing `.yaml`/`.yml` extension handling). Docker Compose files now receive the same completion support as other YAML files.

Because this is the shared Flare language server, the fix applies to every IDE that defers language support to the server (e.g. JetBrains and Eclipse send the document to the server without a client-side language allowlist).

## Testing

- Extended `server/aws-lsp-codewhisperer/src/shared/languageDetection.test.ts`:
  - `getLanguageId` maps the `dockercompose` language id to `yaml`;
  - `getSupportedLanguageId` resolves a `dockercompose` document to `yaml` (a supported language).
- Ran the `languageDetection` unit tests: all passing (8/8).
- `prettier --check` and `eslint` pass on the changed files.

## Notes

- Companion client-side change for VS Code (which additionally gates the inline-completion provider by language id): aws/amazon-q-vscode#141.
