### PR TITLE
fix: pass untrusted event data via env in prerelease workflow

### DIFF
--- a/.github/workflows/create-agentic-github-prerelease.yml
+++ b/.github/workflows/create-agentic-github-prerelease.yml
@@ -26,15 +26,23 @@ jobs:
 
             # if user ran this action manually
             - if: github.event_name == 'workflow_dispatch'
+              env:
+                  # Pass untrusted event data through the environment instead of
+                  # interpolating it directly into the script body.
+                  INPUT_TAG_NAME: ${{ github.event.inputs.tag_name }}
               run: |
-                  echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
-                  echo "PRERELEASE_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+                  echo "TAG_NAME=$INPUT_TAG_NAME" >> $GITHUB_ENV
+                  echo "PRERELEASE_NAME=$INPUT_TAG_NAME" >> $GITHUB_ENV
 
             # Otherwise a push to a branch triggered this action.
             # Set TAG_NAME and PRERELEASE_NAME based on branch name
             - if: github.event_name != 'workflow_dispatch'
+              env:
+                  # Branch names are attacker-controllable, so read the value from the
+                  # environment instead of interpolating it into the script body.
+                  HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
               run: |
-                  BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
+                  BRANCH_NAME="$HEAD_BRANCH"
                   if [[ "$BRANCH_NAME" == "main" ]]; then
                       echo "TAG_NAME=agentic-alpha" >> $GITHUB_ENV
                       echo "PRERELEASE_NAME=alpha" >> $GITHUB_ENV
@@ -53,6 +61,8 @@ jobs:
 
             # Make a sever version that is "decorated" as prerelease
             - name: Create SERVER_VERSION
+              env:
+                  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
               run: |
                   # example: 1.0.999-pre-main.commitid
                   # SERVER_VERSION - we're making "imitation" manifests that are accessible
@@ -61,7 +71,7 @@ jobs:
                   # in the version.json file.
 
                   AGENTIC_VERSION=$(jq -r '.agenticChat' app/aws-lsp-codewhisperer-runtimes/src/version.json)
-                  COMMIT_SHORT=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-8)
+                  COMMIT_SHORT=$(echo "$HEAD_SHA" | cut -c1-8)
                   echo "SERVER_VERSION=$AGENTIC_VERSION-$PRERELEASE_NAME.$COMMIT_SHORT" >> $GITHUB_ENV
 
             - name: Export outputs


### PR DESCRIPTION
## Problem

`.github/workflows/create-agentic-github-prerelease.yml` interpolated `github.event`
values directly into inline `run:` script bodies:

```yaml
echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
COMMIT_SHORT=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-8)
```

GitHub expands `${{ ... }}` textually *before* the shell parses the script, so the
expanded value becomes part of the script source rather than a string argument. A
branch name or workflow input that closes the surrounding quote can therefore append
arbitrary commands, which then run on the runner with the workflow's token and
permissions. Branch names and `workflow_dispatch` inputs are attacker-controllable,
so these are script injection sinks.

See [Understanding the risk of script injections](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

## Solution

Move each untrusted value into a step-level `env:` block and reference it as an
ordinary shell variable, which is the mitigation GitHub
[recommends](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks).
The value is then passed through the environment and is always treated as data, never
as script source.

Three sites changed:

| Value | Step |
| --- | --- |
| `github.event.inputs.tag_name` | `workflow_dispatch` tag/prerelease name |
| `github.event.workflow_run.head_branch` | branch-based tag/prerelease name |
| `github.event.workflow_run.head_sha` | `Create SERVER_VERSION` |

This is the same pattern the `create-release` job in this workflow already uses for
`BRANCH` and `COMMIT_ID`, so the file is now internally consistent.

Scoped to this one workflow — it is the only workflow in the repo that interpolates
`github.event` data into a `run:` block.

## Testing

No behavior change is intended, and the workflow is only reachable from
`workflow_run`, so the branch-name logic was extracted and exercised directly:

- Tag and prerelease names are unchanged for `main`, `feature/*`, and
  `release/agentic/*`:
  - `main` → `TAG_NAME=agentic-alpha`, `PRERELEASE_NAME=alpha`
  - `feature/web-search` → `TAG_NAME=agentic-pre-web-search`, `PRERELEASE_NAME=web-search`
  - `release/agentic/1.26.0` → `TAG_NAME=agentic-rc-1.26.0`, `PRERELEASE_NAME=rc`
- An unsupported branch still exits `1` with the same error message.
- A branch name carrying a quote-breaking payload is stored verbatim as data and the
  payload does not execute. Replaying the same payload through the previous
  inline-interpolation form does execute it, confirming the sink was real and is now
  closed.

Also verified: the file still parses as YAML with both jobs intact, and
`prettier --check` passes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
