### PR TITLE
chore: merge agentic version 1.79.0

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/version.json
+++ b/app/aws-lsp-codewhisperer-runtimes/src/version.json
@@ -1,3 +1,3 @@
 {
-    "agenticChat": "1.78.0"
+    "agenticChat": "1.79.0"
 }


### PR DESCRIPTION
This merges the released changes for 1.79.0 into main.