### PR TITLE
fix: pass workflow inputs via env in release-candidate workflow

### DIFF
--- a/.github/workflows/create-release-candidate-branch.yml
+++ b/.github/workflows/create-release-candidate-branch.yml
@@ -53,9 +53,13 @@ jobs:
               id: release-version
               env:
                   VERSION_FILE: app/aws-lsp-codewhisperer-runtimes/src/version.json
+                  # Bind workflow inputs via env so they are passed as data, not
+                  # expanded into the script source (prevents script injection).
+                  CUSTOM_VERSION: ${{ inputs.customVersion }}
+                  VERSION_INCREMENT: ${{ inputs.versionIncrement }}
               run: |
-                  customVersion="${{ inputs.customVersion }}"
-                  versionIncrement="${{ inputs.versionIncrement }}"
+                  customVersion="$CUSTOM_VERSION"
+                  versionIncrement="$VERSION_INCREMENT"
 
                   # Read current version
                   currentVersion=$(jq -r '.agenticChat' "$VERSION_FILE")


### PR DESCRIPTION
## Problem

`.github/workflows/create-release-candidate-branch.yml` interpolates two `workflow_dispatch` inputs directly into the inline `run:` script of the **Calculate Release Version** step:

```yaml
run: |
    customVersion="${{ inputs.customVersion }}"
    versionIncrement="${{ inputs.versionIncrement }}"
```

GitHub expands `${{ ... }}` textually *before* the shell parses the script, so the input value becomes part of the script source rather than a string argument. `customVersion` is a free-text `string` input; a value such as `1.2.3"; <command>; echo "` closes the surrounding quote and runs arbitrary commands on the runner. This job has `contents: write` and pushes a release branch, so injected commands would run with a token that can write to the repository.

The trigger is `workflow_dispatch` only, so exposure is limited to people who can run workflows, but workflow inputs are still user-controlled and this is the same script-injection pattern that was fixed in the prerelease workflow in #2861.

See [Understanding the risk of script injections](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

## Solution

Bind both inputs to step-level `env:` variables and reference them as ordinary shell variables, the mitigation GitHub [recommends](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks). The values are passed through the environment and are always treated as data.

```yaml
env:
    CUSTOM_VERSION: ${{ inputs.customVersion }}
    VERSION_INCREMENT: ${{ inputs.versionIncrement }}
run: |
    customVersion="$CUSTOM_VERSION"
    versionIncrement="$VERSION_INCREMENT"
```

No behaviour change for legitimate inputs: the rest of the script already consumes `$customVersion` / `$versionIncrement` as shell variables. `ref: ${{ inputs.commitId }}` on `actions/checkout` is an action input, not a script, and is unchanged.

## Testing

- Workflow YAML parses; `prettier --check` passes.
- Replayed the step body with `customVersion` set to a quote-breaking payload: the previous interpolated form executes the injected command; the new env-bound form keeps the whole value as an inert string and `newVersion` is set to that literal.
- Same fix shape as #2861, which has been running in the prerelease workflow since it merged.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
