### PR TITLE
fix(amazonq): mark oversized file context as truncated instead of cutting silently

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
@@ -9,7 +9,7 @@ import { getInitialContextInfo, getUserPromptsDirectory } from './contextUtils'
 import { LocalProjectContextController } from '../../../shared/localProjectContextController'
 import { workspaceUtils } from '@aws/lsp-core'
 import { ChatDatabase } from '../tools/chatDb/chatDb'
-import { TriggerContext } from './agenticChatTriggerContext'
+import { TriggerContext, workspaceChunkMaxSize } from './agenticChatTriggerContext'
 import { expect } from 'chai'
 
 describe('AdditionalContextProvider', () => {
@@ -895,6 +895,53 @@ describe('AdditionalContextProvider', () => {
             assert.strictEqual(result.length, 1)
             // Should use content from the indexing library, not filesystem
             assert.strictEqual(result[0].innerContext, 'Content from indexing library')
+        })
+
+        it('should cap oversized context content and mark it as truncated', async () => {
+            const mockWorkspaceFolder = {
+                uri: URI.file('/workspace').toString(),
+                name: 'test',
+            }
+            sinon.stub(workspaceUtils, 'getWorkspaceFolderPaths').returns(['/workspace'])
+            const triggerContext: TriggerContext = {
+                workspaceFolder: mockWorkspaceFolder,
+            }
+
+            fsExistsStub.callsFake((pathStr: string) => {
+                if (pathStr.includes(path.join('.amazonq', 'rules'))) {
+                    return Promise.resolve(true)
+                }
+                return Promise.resolve(false)
+            })
+            fsReadDirStub.resolves([{ name: 'rule1.md', isFile: () => true, isDirectory: () => false }])
+
+            const largeContent = 'line of text\n'.repeat(10_000)
+            assert.ok(largeContent.length > workspaceChunkMaxSize)
+
+            getContextCommandPromptStub
+                .onFirstCall()
+                .resolves([])
+                .onSecondCall()
+                .resolves([
+                    {
+                        name: 'Large Rule',
+                        description: 'Test Description',
+                        content: largeContent,
+                        filePath: '/workspace/.amazonq/rules/rule1.md',
+                        relativePath: '.amazonq/rules/rule1.md',
+                        startLine: 1,
+                        endLine: 10,
+                    },
+                ])
+
+            const result = await provider.getAdditionalContext(triggerContext, '')
+
+            assert.strictEqual(result.length, 1)
+            const innerContext = result[0].innerContext ?? ''
+            assert.strictEqual(innerContext.length, workspaceChunkMaxSize)
+            assert.ok(innerContext.startsWith('line of text\n'))
+            assert.ok(innerContext.includes('[Content truncated:'))
+            assert.ok(innerContext.includes(`${largeContent.length} characters`))
         })
 
         it('should handle filesystem read errors gracefully in fallback', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
@@ -26,6 +26,7 @@ import {
     getInitialContextInfo,
     promptFileExtension,
     getCodeSymbolDescription,
+    truncateContextContent,
 } from './contextUtils'
 import { LocalProjectContextController } from '../../../shared/localProjectContextController'
 import { Features } from '../../types'
@@ -567,7 +568,7 @@ export class AdditionalContextProvider {
             const entry = {
                 name: prompt.name.substring(0, additionalContentNameLimit),
                 description: '',
-                innerContext: prompt.content.substring(0, workspaceChunkMaxSize),
+                innerContext: truncateContextContent(prompt.content, workspaceChunkMaxSize),
                 type: contextType,
                 path: prompt.filePath,
                 relativePath: relativePath,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.test.ts
@@ -9,6 +9,7 @@ import {
     mergeRelevantTextDocuments,
     mergeFileLists,
     getCodeSymbolDescription,
+    truncateContextContent,
 } from './contextUtils'
 import * as pathUtils from '@aws/lsp-core/out/util/path'
 import { sanitizeFilename } from '@aws/lsp-core/out/util/text'
@@ -426,6 +427,40 @@ describe('contextUtils', () => {
 
             const result = getCodeSymbolDescription(item, false)
             expect(result).to.equal(`Interface, ${path.join('workspace', 'src', 'models.ts')}`)
+        })
+    })
+
+    describe('truncateContextContent', () => {
+        it('returns content unchanged when it fits within the limit', () => {
+            const content = 'short content'
+            expect(truncateContextContent(content, 100)).to.equal(content)
+        })
+
+        it('returns content unchanged when it is exactly the limit', () => {
+            const content = 'a'.repeat(50)
+            expect(truncateContextContent(content, 50)).to.equal(content)
+        })
+
+        it('appends a truncation marker and never exceeds the limit', () => {
+            const lines = Array.from({ length: 1000 }, (_, i) => `This is line ${i + 1} of a large file.`)
+            const content = lines.join('\n')
+            const maxLength = 4096
+
+            const result = truncateContextContent(content, maxLength)
+
+            expect(result.length).to.equal(maxLength)
+            expect(result.startsWith('This is line 1 of a large file.')).to.equal(true)
+            expect(result).to.include('[Content truncated:')
+            expect(result).to.include(`${content.length} characters`)
+            // The marker must be the tail of the result so the model sees it after the excerpt
+            expect(result.endsWith('Read the file directly to see the rest.]')).to.equal(true)
+        })
+
+        it('falls back to a plain cut when the limit is too small for the marker', () => {
+            const content = 'x'.repeat(500)
+            const result = truncateContextContent(content, 10)
+
+            expect(result).to.equal('x'.repeat(10))
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
@@ -66,6 +66,31 @@ export const getUserPromptsDirectory = (): string => {
 }
 
 /**
+ * Truncates context content (e.g. an `@file` or pinned file) to `maxLength` characters.
+ *
+ * When the content is cut, an explicit marker is appended so the model knows it is only
+ * seeing the beginning of the file and should read the rest via tools instead of assuming
+ * the file ends where the excerpt ends. The returned string never exceeds `maxLength`.
+ *
+ * @param content - Full content of the context item
+ * @param maxLength - Maximum number of characters allowed for the returned string
+ * @returns The original content if it fits, otherwise a truncated prefix followed by a marker
+ */
+export function truncateContextContent(content: string, maxLength: number): string {
+    if (content.length <= maxLength) {
+        return content
+    }
+
+    const marker = `\n\n[Content truncated: this file has ${content.length} characters, only the beginning is included above. Read the file directly to see the rest.]`
+
+    if (marker.length >= maxLength) {
+        return content.substring(0, maxLength)
+    }
+
+    return content.substring(0, maxLength - marker.length) + marker
+}
+
+/**
  * Creates a secure file path for a new prompt file.
  *
  * @param promptName - The user-provided name for the prompt


### PR DESCRIPTION
## Problem

When a file is added to a chat prompt as context (for example via `@file` or as pinned context), its content is capped at `workspaceChunkMaxSize` (40,960 characters) before it is sent to the model. The cap is applied with a plain `substring(0, max)` and nothing indicates that a cut happened.

For a large file this is misleading: the model receives only the first ~40K characters (roughly the first 250 lines of a typical text file) with no hint that more exists, and it confidently reports the wrong file size. Example: attaching a 10,000-line file and asking about lines 1240–1570 yields an answer along the lines of "the file only contains 251 lines, those lines don't exist", even though the model has tools available to read the rest of the file.

The same file works correctly when it is the active editor file, because that path does not go through this cap, which makes the inconsistency confusing for users.

## Solution

- Add `truncateContextContent(content, maxLength)` in `contextUtils.ts`. When `content` exceeds `maxLength` it returns the leading prefix followed by an explicit marker:

  ```
  [Content truncated: this file has N characters, only the beginning is included above. Read the file directly to see the rest.]
  ```

  The marker is carved out of the same budget, so the returned string never exceeds `maxLength` (the outgoing payload size is unchanged). If `maxLength` is too small to fit the marker, it falls back to the previous plain cut.
- Use the helper for `innerContext` in `AdditionalContextProvider.getAdditionalContext` instead of the bare `substring`.

The model now knows the excerpt is partial and can read the remainder with its file tools instead of assuming the file ends where the excerpt ends. No public API or protocol changes.

### Testing

- New unit tests in `contextUtils.test.ts` cover: content within the limit is unchanged, content exactly at the limit is unchanged, oversized content is capped exactly at the limit with the marker as the tail (including the original character count), and the small-limit fallback.
- New test in `additionalContextProvider.test.ts` runs an oversized file through `getAdditionalContext` and asserts the resulting `innerContext` is capped at `workspaceChunkMaxSize` and carries the marker.
- `ts-mocha` on the two affected test files: 57 passing. `prettier` and `eslint` clean on the changed files (only pre-existing `import/no-nodejs-modules` warnings).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
